### PR TITLE
Deploy website to GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # dofunthings
 Do Fun Things
+
+## Deploying to GitHub Pages
+
+To deploy this website to GitHub Pages, follow these steps:
+
+1. Go to the repository settings on GitHub.
+2. Navigate to the "Pages" section.
+3. Select the branch you want to deploy (usually `main` or `master`) and the root folder.
+4. Click "Save" to deploy the website.
+
+The website will be accessible at `https://bekahwhittle.github.io/dofunthings`.
+
+**Note:** Ensure the `index.html` file is in the root directory of your branch to allow GitHub Pages to serve your website correctly.


### PR DESCRIPTION
Updates the README.md file to include instructions for deploying the website to GitHub Pages.

- Adds a new section titled "Deploying to GitHub Pages" with step-by-step instructions on how to deploy the website using GitHub's repository settings.
- Provides the URL where the deployed website will be accessible.
- Includes a note emphasizing the importance of having the `index.html` file in the root directory for correct serving by GitHub Pages.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/bekahwhittle/dofunthings?shareId=e29df78a-7ee8-4825-9fed-5bcc9c87444d).